### PR TITLE
feat: add an xss echobox component

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import './App.css';
 import PetForm from './Forms/PetForm';
 // import FeedbackForm from './Forms/FeedbackForm';
+import EchoBox from './Components/Echobox';
 
 function App() {
   return (
@@ -21,11 +22,20 @@ function App() {
         <br />
 
         <p>Want to see my favourite cat video?</p>
-        <a class="button" href="https://www.youtube.com/watch?v=wB9afdV2BgA">Click me!</a>
+        <a className="button" href="https://www.youtube.com/watch?v=wB9afdV2BgA">Click me!</a>
 
         <br />
+        <br />
+        <br />
+        <br />
+        
+        <EchoBox />
 
         <br />
+        <br />
+        <br />
+        <br />
+
         
         <p>
           <a

--- a/src/Components/Echobox.css
+++ b/src/Components/Echobox.css
@@ -1,0 +1,45 @@
+
+.echo-card {
+    border: 3px solid #ff00b8;
+    border-radius: 8px;
+    padding: 16px;
+    max-width: 500px;
+    margin: 16px auto;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+
+.echo-input {
+    width: 85%;
+    padding: 8px;
+    margin-top: 8px;
+    border: 1px solid #aaa;
+    border-radius: 4px;
+    font-family: inherit;
+}
+
+
+.echo-actions {
+    margin-top: 12px;
+    border-radius: 99px;
+    color: #fff;
+    background-color: #ff00b8;
+    cursor: pointer;
+    border: 15px solid #ff00b8;
+    text-decoration: none;
+    width: 40%;
+    justify-content: center;
+    font-size: calc(10px + 2vmin);
+}
+
+.echo-output {
+    margin-top: 50px;
+}
+
+.echo-preview {
+    margin-top: 12px;
+    padding: 8px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    min-height: 40px;
+}

--- a/src/Components/Echobox.js
+++ b/src/Components/Echobox.js
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+import './Echobox.css';
+
+function EchoBox() {
+    const [text, setText] = useState('');
+    const [echoed, setEchoed] = useState('');
+
+
+    return (
+        <div className="echo-card">
+            <h2>EchoBox</h2>
+            <p>This will take some input and paste it back so you can preview it.</p>
+            <textarea
+                className="echo-input"
+                value={text}
+                onChange={e => setText(e.target.value)}
+                placeholder="Type something here..."
+                rows={6}
+            />
+            <div>
+                <button className='echo-actions' onClick={() => setEchoed(text)}>Echo</button>
+            </div>
+
+            <div className='echo-output'>
+                <span>Preview:</span>
+                <div
+                    className="echo-preview"
+                    dangerouslySetInnerHTML={{ __html: echoed }}
+                />
+            </div>
+            
+        </div>
+    );
+}
+
+export default EchoBox;


### PR DESCRIPTION
Adding a XSS demo. Lmk if this might be too difficult or easy and I can change it

![xss-demo](https://github.com/user-attachments/assets/8097a456-b524-49a0-8088-46dfcb73e9ad)

The idea is to not use `dangerouslySetInnerHTML`

```
<div className='echo-output'>
  <span>Preview:</span>
   {/* <div
             className="echo-preview"
             dangerouslySetInnerHTML={{ __html: echoed }}
   /> */}
   <div className="echo-preview">{echoed}</div>
 </div>
```
